### PR TITLE
Allow to set custom FPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Records mouse movement to a file and opens it in After Effects. Use with [OBS St
 ### With OBS (manually)
 1. #### Import the [cursor_recorder_for_obs.py][cursor_recorder_for_obs] in OBS. (You need to do this just once).
    1. Go to `Tools -> Scripts`.
-   2. Make sure you have a Python interpreter set in your settings (`Scripts -> Python Settings`).
+   2. Make sure you have a Python interpreter installed and its path set in OBS' settings (`Scripts -> Python Settings`).
    3. Click the :heavy_plus_sign: icon (Add Scripts) and select the [cursor_recorder_for_obs.py][cursor_recorder_for_obs].
    4. Make sure the script is enabled. (It is by default).
    5. Click `Install Python modules` if you don't have `pyautogui` and/or `keyboard` packages installed.

--- a/scripts/cursor_recorder_for_afterfx.jsx
+++ b/scripts/cursor_recorder_for_afterfx.jsx
@@ -14,6 +14,10 @@ function main() {
 	if (!app.project.activeItem || app.project.activeItem === 'undefined') {
 		alert("A composition must be open and selected!");
 		return;
+	} 
+	if (app.project.activeItem.typeName != "Composition") {
+		alert("You did not select a composition, but a " + app.project.activeItem.typeName + "!");
+		return;
 	}
 
 	var file = new File(

--- a/scripts/cursor_recorder_for_afterfx.jsx
+++ b/scripts/cursor_recorder_for_afterfx.jsx
@@ -11,7 +11,7 @@
 
 main();
 function main() {
-	if (!app.project.activeItem) {
+	if (!app.project.activeItem || app.project.activeItem === 'undefined') {
 		alert("A composition must be open and selected!");
 		return;
 	}

--- a/scripts/cursor_recorder_for_afterfx.jsx
+++ b/scripts/cursor_recorder_for_afterfx.jsx
@@ -28,7 +28,7 @@ function main() {
 	if (file.open("r")) {
 		file.encoding = "UTF-8";
 		var myNull = app.project.activeItem.layers.addNull();
-		myNull.name = file.name;
+		myNull.name = "cursor-recorder";
 		var last_time = 0;
 		while (1) {
 			var line = file.readln();


### PR DESCRIPTION
Uses the standalone's way of getting the time instead of relying on OBS to get the seconds variable.

Uses threading to start a new thread to get the cursor movement data.